### PR TITLE
Update writable.php

### DIFF
--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -72,7 +72,7 @@ task('deploy:writable', function () {
         if ($httpGroup === false) {
             throw new \RuntimeException("Please setup `http_group` config parameter.");
         }
-        run("$sudo chgrp -H $recursive $httpGroup $dirs");
+        run("$sudo chgrp -H -f $recursive $httpGroup $dirs");
     } elseif ($mode === 'chmod') {
         // in chmod mode, defined `writable_chmod_recursive` has priority over common `writable_recursive`
         if (is_bool(get('writable_chmod_recursive'))) {


### PR DESCRIPTION
Silence the errors from chgrp. Will not interrupt deploy process in case the group ownership is already correct, but user is different.

- [x] Bug fix #2571?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

      Please, update CHANGELOG.md by running next command:
      $ php bin/changelog
